### PR TITLE
update version of gettext-parser requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@ngx-translate/core": "^10.0.0"
   },
   "dependencies": {
-    "gettext-parser": "1.3.1"
+    "gettext-parser": "^2.1.0"
   },
   "devDependencies": {
     "@angular/core": "^6.0.0",


### PR DESCRIPTION
**Thanks** for this great lib! Usage of PO file is a great enhancement!

---

Fix issue [22](https://github.com/biesbjerg/ngx-translate-po-http-loader/issues/22) since it was related to [an issue](https://github.com/smhg/gettext-parser/pull/42) of `gettext-parser`.

I already made [a fix](https://github.com/smhg/gettext-parser/pull/46) that has been released on the dependency so we just need to upgrade to the new version.

### Special note:

Since my fix on `gettext-parser` was linked to a limitation of old nodejs version we have two new version of `gettext-parser` (V2.x and V3.x), i decided to put the v2 in this PR to support old node version since this lib is really short in code. 

### Analyse of breaking changes:

From 1.x to [2.x](https://github.com/smhg/gettext-parser/releases/tag/v2.0.0) we have only one breaking change:

```
BREAKING: sortByMsgId parameter was renamed to sort
```

But we don't use this function in this library, so we can upgrade easily :)